### PR TITLE
GraphQL filter by quarkus version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ And it should return:
 
 When running the REST API service, it also runs a GraphQL endpoint at `/graphql-ui` (in production mode).
 
-At the moment, there are four queries:
+At the moment, there are five queries:
 
 - repositories:
 
@@ -108,9 +108,11 @@ At the moment, there are four queries:
     id
     repoUrl
     name
+    quarkusVersion
     branch
     extensions {
       name
+      version
     }
     labels
     createdAt
@@ -118,6 +120,22 @@ At the moment, there are four queries:
     status
    }
 }
+
+// It's also possible filter by quarkus version:
+{
+ repositories(quarkusVersions:["999-SNAPSHOT", "1.10.2.Final"]) {
+    id
+    repoUrl
+    name
+    quarkusVersion
+    branch
+    labels
+    createdAt
+    updatedAt
+    status
+ }
+}
+
 ```
 
 - by repository URL:
@@ -131,6 +149,7 @@ At the moment, there are four queries:
     branch
     extensions {
       name
+      version
     }
     labels
     createdAt
@@ -151,6 +170,7 @@ At the moment, there are four queries:
     branch
     extensions {
       name
+      version
     }
     labels
     createdAt
@@ -164,16 +184,35 @@ At the moment, there are four queries:
 
 ```
 {
-   repositoriesByExtensions (extensions: ["quarkus-json", "quarkus-rest"]) {
+  repositoriesByExtensions(extensions: [{name: "quarkus-grpc", version: "1.10.2.Final"}]) {
     id
     repoUrl
     name
+    quarkusVersion
     branch
     labels
     createdAt
     updatedAt
     status
-   }
+  }
+}
+```
+
+- repositories that use any of a list of artifactIds:
+
+```
+{
+  repositoriesByExtensionsArtifactIds(artifactIds: ["quarkus-grpc", "quarkus-jdbc-h2"]) {
+    id
+    repoUrl
+    name
+    quarkusVersion
+    branch
+    labels
+    createdAt
+    updatedAt
+    status
+  }
 }
 ```
 

--- a/data/src/main/java/io/quarkus/qe/data/QuarkusVersionEntity.java
+++ b/data/src/main/java/io/quarkus/qe/data/QuarkusVersionEntity.java
@@ -9,4 +9,10 @@ public class QuarkusVersionEntity extends PanacheEntityBase {
     @Id
     public String id;
 
+    public QuarkusVersionEntity() {
+    }
+
+    public QuarkusVersionEntity(String id) {
+        this.id = id;
+    }
 }

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -47,6 +47,11 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-container-image-jib</artifactId>
         </dependency>
 

--- a/rest-api/src/main/java/io/quarkus/qe/SearchResource.java
+++ b/rest-api/src/main/java/io/quarkus/qe/SearchResource.java
@@ -1,16 +1,18 @@
 package io.quarkus.qe;
 
+import io.quarkus.qe.model.QuarkusExtension;
 import java.util.List;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.graphql.Description;
-import org.eclipse.microprofile.graphql.GraphQLApi;
-import org.eclipse.microprofile.graphql.Query;
-
 import io.quarkus.qe.exceptions.RepositoryNotFoundException;
 import io.quarkus.qe.model.Repository;
 import io.quarkus.qe.services.RepositoryService;
+import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.Query;
 
 @GraphQLApi
 public class SearchResource {
@@ -20,25 +22,31 @@ public class SearchResource {
 
     @Query("repositories")
     @Description("Get all repositories")
-    public List<Repository> getAllRepositories() {
-        return repositoryService.findAll();
+    public List<Repository> getAllRepositories(@Name("quarkusVersions") @DefaultValue("[]") List<String> versions) {
+        return repositoryService.findAll(versions);
     }
 
     @Query("repositoryById")
     @Description("Get repository by ID")
-    public Repository getRepositoryByRepoUrl(long id) throws RepositoryNotFoundException {
+    public Repository getRepositoryByRepoUrl(@Name("id") long id) throws RepositoryNotFoundException {
         return repositoryService.findById(id);
     }
 
     @Query("repositoryByUrl")
     @Description("Get repository by repository URL")
-    public Repository getRepositoryByRepoUrl(String repoUrl) throws RepositoryNotFoundException {
+    public Repository getRepositoryByRepoUrl(@Name("repoUrl") String repoUrl) throws RepositoryNotFoundException {
         return repositoryService.findByRepoUrl(repoUrl);
     }
 
     @Query("repositoriesByExtensions")
     @Description("Get repositories using a list of extensions")
-    public List<Repository> getRepositoriesByExtension(List<String> extensions) {
+    public List<Repository> getRepositoriesByExtension(@Name("extensions") List<QuarkusExtension> extensions) {
         return repositoryService.findByExtensions(extensions);
+    }
+
+    @Query("repositoriesByExtensionsArtifactIds")
+    @Description("Get repositories using a list of extensions artifacts ids")
+    public List<Repository> getRepositoriesByExtensionArtifactIds(@Name("artifactIds") List<String> artifactIds) {
+        return repositoryService.findByExtensionsArtifactIds(artifactIds);
     }
 }

--- a/rest-api/src/main/java/io/quarkus/qe/services/RepositoryService.java
+++ b/rest-api/src/main/java/io/quarkus/qe/services/RepositoryService.java
@@ -1,6 +1,9 @@
 package io.quarkus.qe.services;
 
-import java.util.List;
+import io.quarkus.panache.common.Parameters;
+import io.quarkus.qe.data.QuarkusVersionEntity;
+import io.quarkus.qe.model.QuarkusExtension;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -9,7 +12,6 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 
-import io.quarkus.panache.common.Parameters;
 import io.quarkus.qe.configuration.Channels;
 import io.quarkus.qe.data.RepositoryEntity;
 import io.quarkus.qe.data.marshallers.RepositoryMarshaller;
@@ -40,10 +42,34 @@ public class RepositoryService {
         return repositoryMarshaller.fromEntity(entity);
     }
 
-    public List<Repository> findByExtensions(List<String> extensions) {
+    public List<Repository> findByExtensionsArtifactIds(List<String> artifactIDs) {
         return RepositoryEntity.<RepositoryEntity> find(
                 "select distinct repo from repository repo inner join fetch repo.extensions ext where ext.name IN :names",
-                Parameters.with("names", extensions)).stream()
+                Parameters.with("names", artifactIDs)).stream()
+                .map(repositoryMarshaller::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public List<Repository> findByExtensions(List<QuarkusExtension> extensions) {
+        // compose query
+        StringBuilder sql = new StringBuilder();
+        sql.append("select distinct repo from repository repo inner join fetch repo.extensions ext\t");
+        Iterator<QuarkusExtension> it = extensions.iterator();
+        if (it.hasNext()) {
+            QuarkusExtension extensionVersion = it.next();
+            sql.append("where\t");
+            String nameVersionStatement = "ext.name = '%s' and ext.version = '%s'\t";
+            sql.append(String.format(nameVersionStatement, extensionVersion.getName(), extensionVersion.getVersion()));
+            while (it.hasNext()) {
+                extensionVersion = it.next();
+                sql.append("or\t");
+                sql.append(String.format(nameVersionStatement, extensionVersion.getName(), extensionVersion.getVersion()));
+            }
+        }
+
+        // make query
+        return RepositoryEntity.<RepositoryEntity> find(sql.toString())
+                .stream()
                 .map(repositoryMarshaller::fromEntity)
                 .collect(Collectors.toList());
     }
@@ -57,8 +83,17 @@ public class RepositoryService {
         return repositoryMarshaller.fromEntity(entity);
     }
 
-    public List<Repository> findAll() {
-        return RepositoryEntity.<RepositoryEntity> findAll()
+    public List<Repository> findAll(List<String> versions) {
+        StringBuilder sql = new StringBuilder();
+        String quarkusVersionParamName = "quarkusVersion";
+        sql.append("select distinct repo from repository repo\t");
+        Map<String, Object> versionsParam = getQuarkusVersionAsQueryParam(quarkusVersionParamName, versions);
+
+        if (!versionsParam.isEmpty()) {
+            sql.append("where quarkusVersion IN :" + quarkusVersionParamName);
+        }
+
+        return RepositoryEntity.<RepositoryEntity> find(sql.toString(), versionsParam)
                 .stream()
                 .map(repositoryMarshaller::fromEntity)
                 .collect(Collectors.toList());
@@ -81,5 +116,19 @@ public class RepositoryService {
 
     public void updateRepositoryRequest(long id) throws RepositoryNotFoundException {
         enrichEmitter.send(findById(id));
+    }
+
+    private Map<String, Object> getQuarkusVersionAsQueryParam(String parameterName, List<String> versions) {
+        Map<String, Object> params = new HashMap<>();
+        List<QuarkusVersionEntity> versionsParam = versions.stream()
+                .map(QuarkusVersionEntity::new)
+                .filter(quarkusVersion -> Objects.nonNull(quarkusVersion.id))
+                .collect(Collectors.toList());
+
+        if (!versionsParam.isEmpty()) {
+            params.put(parameterName, versionsParam);
+        }
+
+        return params;
     }
 }


### PR DESCRIPTION
- Update readme with previous Quarkus extension Version changes.
- Update GraphQL `repositoriesByExtensions` in order to search by extension name and version
- Update GraphQL `repositories`  in order to filter by quarkusVersion
- Create GraphQL `repositoriesByExtensionsArtifactIds` that corresponds with the old `repositoriesByExtensions` operation