### PR TITLE
Remove database unused db and kafka properties from helm values. Move…

### DIFF
--- a/deployment/charts/catalog-enricher-service/Chart.yaml
+++ b/deployment/charts/catalog-enricher-service/Chart.yaml
@@ -4,5 +4,5 @@ name: catalog-enricher-service
 version: 0.0.1
 dependencies:
 - name: qe-quarkus-app
-  version: 0.0.1
+  version: 0.0.2
   repository: http://quarkus-qe.github.io/helm-charts-parent

--- a/deployment/charts/catalog-enricher-service/values.yaml
+++ b/deployment/charts/catalog-enricher-service/values.yaml
@@ -3,7 +3,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 qe-quarkus-app:
-  replicaCount: 1
+  autoscaler:
+    minReplicas: 1
+    maxReplicas: 1
   deployment:
     name: catalog-enricher-api
     image:
@@ -26,10 +28,10 @@ qe-quarkus-app:
     type: ClusterIP
     externalPort: 8083
     internalPort: 8083
-  database:
-    url: jdbc:postgresql://dev-quarkusappcatalog.postgresql-qe-infra:5432/quarkusappcatalog
-    user: root
-    pwd: EWQNNZC
-    schema: quarkusappcatalog
-  kafka:
-    bootstrap: dev-kafka-qe-kafka-bootstrap.kafka-qe-infra:9092
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "500Mi"
+    requests:
+      cpu: "150m"
+      memory: "175Mi"

--- a/deployment/charts/catalog-rest-api/Chart.yaml
+++ b/deployment/charts/catalog-rest-api/Chart.yaml
@@ -4,5 +4,5 @@ name: catalog-rest-api
 version: 0.0.1
 dependencies:
   - name: qe-quarkus-app
-    version: 0.0.1
+    version: 0.0.2
     repository: http://quarkus-qe.github.io/helm-charts-parent

--- a/deployment/charts/catalog-rest-api/values.yaml
+++ b/deployment/charts/catalog-rest-api/values.yaml
@@ -5,7 +5,7 @@
 qe-quarkus-app:
   autoscaler:
     minReplicas: 1
-    maxReplicas: 3
+    maxReplicas: 1
   deployment:
     name: catalog-rest-api
     image:

--- a/deployment/charts/catalog-rest-api/values.yaml
+++ b/deployment/charts/catalog-rest-api/values.yaml
@@ -3,7 +3,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 qe-quarkus-app:
-  replicaCount: 1
+  autoscaler:
+    minReplicas: 1
+    maxReplicas: 3
   deployment:
     name: catalog-rest-api
     image:
@@ -27,3 +29,10 @@ qe-quarkus-app:
     type: ClusterIP
     externalPort: 8081
     internalPort: 8081
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "500Mi"
+    requests:
+      cpu: "150m"
+      memory: "175Mi"

--- a/deployment/charts/catalog-storage-service/Chart.yaml
+++ b/deployment/charts/catalog-storage-service/Chart.yaml
@@ -4,5 +4,5 @@ name: catalog-storage-service
 version: 0.0.2
 dependencies:
   - name: qe-quarkus-app
-    version: 0.0.1
+    version: 0.0.2
     repository: http://quarkus-qe.github.io/helm-charts-parent

--- a/deployment/charts/catalog-storage-service/values.yaml
+++ b/deployment/charts/catalog-storage-service/values.yaml
@@ -5,7 +5,7 @@
 qe-quarkus-app:
   autoscaler:
     minReplicas: 1
-    maxReplicas: 3
+    maxReplicas: 1
   deployment:
     name: catalog-storage-api
     image:

--- a/deployment/charts/catalog-storage-service/values.yaml
+++ b/deployment/charts/catalog-storage-service/values.yaml
@@ -3,7 +3,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 qe-quarkus-app:
-  replicaCount: 1
+  autoscaler:
+    minReplicas: 1
+    maxReplicas: 3
   deployment:
     name: catalog-storage-api
     image:
@@ -26,11 +28,12 @@ qe-quarkus-app:
     type: ClusterIP
     externalPort: 8082
     internalPort: 8082
-  database:
-    url: jdbc:postgresql://dev-quarkusappcatalog.postgresql-qe-infra:5432/quarkusappcatalog
-    user: root
-    pwd: EWQNNZC
-    schema: quarkusappcatalog
-  kafka:
-    bootstrap: dev-kafka-qe-kafka-bootstrap.kafka-qe-infra:9092
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "500Mi"
+    requests:
+      cpu: "150m"
+      memory: "175Mi"
+
 


### PR DESCRIPTION
- Remove database unused db and kafka properties from helm values.
- Move on to parent chart 0.0.2

**NOTE:** This PR depends on [this one](https://github.com/quarkus-qe/helm-charts-parent/pull/1)